### PR TITLE
Added hotkey icons to 'End turn' and 'Stats' buttons

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -42,6 +42,7 @@ Online="*res://scripts/services/online.gd"
 Multiplayer="*res://scripts/services/multiplayer.gd"
 Autodiscovery="*res://scripts/services/autodiscovery.gd"
 Relay="*res://scripts/services/relay.gd"
+ButtonHotkeyService="*res://scripts/services/button_hotkey_service.gd"
 
 [debug]
 

--- a/scenes/ui/board/hover_menu.tscn
+++ b/scenes/ui/board/hover_menu.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=13 format=3 uid="uid://ce08h2jnhhsh4"]
+[gd_scene load_steps=14 format=3 uid="uid://ce08h2jnhhsh4"]
 
 [ext_resource type="Script" path="res://scenes/ui/board/hover_menu.gd" id="1_j6ss3"]
 [ext_resource type="Texture2D" uid="uid://b5k32hj4wy5tb" path="res://assets/gui/editor/circle_white.png" id="2_0uiag"]
 [ext_resource type="Texture2D" uid="uid://biu2u7rf4o1vh" path="res://assets/gui/editor/circle.png" id="3_nd642"]
 [ext_resource type="PackedScene" uid="uid://npd40qtkohuq" path="res://scenes/ui/icons/coin.tscn" id="4_5ny1k"]
 [ext_resource type="PackedScene" uid="uid://brl2hwxvkhpsm" path="res://scenes/ui/icons/hourglass.tscn" id="4_d3xti"]
+[ext_resource type="PackedScene" uid="uid://dbuy7ss84alp" path="res://scenes/ui/icons/hotkey.tscn" id="5_daydi"]
 [ext_resource type="PackedScene" uid="uid://cpeera0162bio" path="res://scenes/ui/icons/star2.tscn" id="5_m6cda"]
 [ext_resource type="PackedScene" path="res://scenes/ui/icons/info.tscn" id="5_ocuec"]
 
@@ -128,6 +129,13 @@ texture = ExtResource("3_nd642")
 
 [node name="hourglass" parent="turn_button/icon_anchor" instance=ExtResource("4_d3xti")]
 
+[node name="hotkey" parent="turn_button/icon_anchor" instance=ExtResource("5_daydi")]
+position = Vector2(40, 40)
+scale = Vector2(2, 2)
+region_rect = Rect2(336, 64, 16, 16)
+keyboard_frame = 157
+gamepad_frame = 50
+
 [node name="mouse_click" type="Area2D" parent="turn_button"]
 
 [node name="collision" type="CollisionShape2D" parent="turn_button/mouse_click"]
@@ -184,6 +192,13 @@ texture = ExtResource("3_nd642")
 
 [node name="info" parent="stats_button/button_anchor/icon_anchor" instance=ExtResource("5_ocuec")]
 
+[node name="hotkey" parent="stats_button/button_anchor/icon_anchor" instance=ExtResource("5_daydi")]
+position = Vector2(40, 40)
+scale = Vector2(2, 2)
+region_rect = Rect2(320, 64, 16, 16)
+keyboard_frame = 156
+gamepad_frame = 49
+
 [node name="mouse_click" type="Area2D" parent="stats_button/button_anchor"]
 
 [node name="collision" type="CollisionShape2D" parent="stats_button/button_anchor/mouse_click"]
@@ -223,12 +238,3 @@ libraries = {
 "": SubResource("AnimationLibrary_kefv0")
 }
 speed_scale = 4.0
-
-[connection signal="mouse_entered" from="turn_button/mouse_click" to="." method="_on_mouse_click_mouse_entered" binds= ["turn"]]
-[connection signal="mouse_exited" from="turn_button/mouse_click" to="." method="_on_mouse_click_mouse_exited" binds= ["turn"]]
-[connection signal="mouse_entered" from="build_button/button_anchor/mouse_click" to="." method="_on_mouse_click_mouse_entered" binds= ["build"]]
-[connection signal="mouse_exited" from="build_button/button_anchor/mouse_click" to="." method="_on_mouse_click_mouse_exited" binds= ["build"]]
-[connection signal="mouse_entered" from="stats_button/button_anchor/mouse_click" to="." method="_on_mouse_click_mouse_entered" binds= ["stats"]]
-[connection signal="mouse_exited" from="stats_button/button_anchor/mouse_click" to="." method="_on_mouse_click_mouse_exited" binds= ["stats"]]
-[connection signal="mouse_entered" from="skills_button/button_anchor/mouse_click" to="." method="_on_mouse_click_mouse_entered" binds= ["skills"]]
-[connection signal="mouse_exited" from="skills_button/button_anchor/mouse_click" to="." method="_on_mouse_click_mouse_exited" binds= ["skills"]]

--- a/scenes/ui/board/hover_menu.tscn
+++ b/scenes/ui/board/hover_menu.tscn
@@ -238,3 +238,12 @@ libraries = {
 "": SubResource("AnimationLibrary_kefv0")
 }
 speed_scale = 4.0
+
+[connection signal="mouse_entered" from="turn_button/mouse_click" to="." method="_on_mouse_click_mouse_entered" binds= ["turn"]]
+[connection signal="mouse_exited" from="turn_button/mouse_click" to="." method="_on_mouse_click_mouse_exited" binds= ["turn"]]
+[connection signal="mouse_entered" from="build_button/button_anchor/mouse_click" to="." method="_on_mouse_click_mouse_entered" binds= ["build"]]
+[connection signal="mouse_exited" from="build_button/button_anchor/mouse_click" to="." method="_on_mouse_click_mouse_exited" binds= ["build"]]
+[connection signal="mouse_entered" from="stats_button/button_anchor/mouse_click" to="." method="_on_mouse_click_mouse_entered" binds= ["stats"]]
+[connection signal="mouse_exited" from="stats_button/button_anchor/mouse_click" to="." method="_on_mouse_click_mouse_exited" binds= ["stats"]]
+[connection signal="mouse_entered" from="skills_button/button_anchor/mouse_click" to="." method="_on_mouse_click_mouse_entered" binds= ["skills"]]
+[connection signal="mouse_exited" from="skills_button/button_anchor/mouse_click" to="." method="_on_mouse_click_mouse_exited" binds= ["skills"]]

--- a/scenes/ui/icons/hotkey.gd
+++ b/scenes/ui/icons/hotkey.gd
@@ -1,0 +1,56 @@
+@tool
+extends Sprite2D
+
+@export var keyboard_frame:int:
+	set(val):
+		keyboard_frame = val
+		if Engine.is_editor_hint():
+			region_rect = get_atlas_rect(keyboard_frame, keyboard_cell_size)
+		else:
+			_update_icon()
+@export var keyboard_cell_size:Vector2 = Vector2(1,1):
+	set(val):
+		keyboard_cell_size = val
+		if Engine.is_editor_hint():
+			region_rect = get_atlas_rect(keyboard_frame, keyboard_cell_size)
+		else:
+			_update_icon()
+@export var gamepad_frame:int:
+	set(val):
+		gamepad_frame = val
+		if Engine.is_editor_hint():
+			region_rect = get_atlas_rect(gamepad_frame, gamepad_cell_size)
+		else:
+			_update_icon()
+@export var gamepad_cell_size:Vector2 = Vector2(1,1):
+	set(val):
+		gamepad_cell_size = val
+		if Engine.is_editor_hint():
+			region_rect = get_atlas_rect(gamepad_frame, gamepad_cell_size)
+		else:
+			_update_icon()
+
+
+const atlas_params := {
+	atlas_size = Vector2(34, 24),
+}
+
+func _ready() -> void:
+	if Engine.is_editor_hint():
+		region_rect = get_atlas_rect(keyboard_frame, keyboard_cell_size)
+		return
+	ButtonHotkeyService.mode_changed.connect(_update_icon)
+	_update_icon()
+
+func _update_icon():
+	match ButtonHotkeyService.current_mode:
+		ButtonHotkeyService.MODE.KEYBOARD:
+			region_rect = get_atlas_rect(keyboard_frame, keyboard_cell_size)
+		ButtonHotkeyService.MODE.GAMEPAD:
+			region_rect = get_atlas_rect(gamepad_frame, gamepad_cell_size)
+
+func get_atlas_rect(atlas_frame:int, size:Vector2 = Vector2(1,1)):
+	var altasCellSize = texture.get_size() / atlas_params.atlas_size
+	var hframe :float = atlas_frame % int(atlas_params.atlas_size.x)
+	var vframe :float = floorf(float(atlas_frame) / atlas_params.atlas_size.x)
+	return Rect2(altasCellSize*Vector2(hframe, vframe), altasCellSize*size)

--- a/scenes/ui/icons/hotkey.gd
+++ b/scenes/ui/icons/hotkey.gd
@@ -1,6 +1,8 @@
 @tool
 extends Sprite2D
 
+enum DISPLAY_MODE {BOTH, KEYBOARD, GAMEPAD}
+
 @export var keyboard_frame:int:
 	set(val):
 		keyboard_frame = val
@@ -29,6 +31,18 @@ extends Sprite2D
 			region_rect = get_atlas_rect(gamepad_frame, gamepad_cell_size)
 		else:
 			_update_icon()
+@export var display_mode :DISPLAY_MODE = DISPLAY_MODE.BOTH:
+	set(val):
+		display_mode = val
+		if Engine.is_editor_hint():
+			match val:
+				DISPLAY_MODE.GAMEPAD:
+					region_rect = get_atlas_rect(gamepad_frame, gamepad_cell_size)
+				_:
+					region_rect = get_atlas_rect(keyboard_frame, keyboard_cell_size)
+		else:
+			_update_icon()
+
 
 
 const atlas_params := {
@@ -37,7 +51,10 @@ const atlas_params := {
 
 func _ready() -> void:
 	if Engine.is_editor_hint():
-		region_rect = get_atlas_rect(keyboard_frame, keyboard_cell_size)
+		if display_mode == DISPLAY_MODE.GAMEPAD:
+			region_rect = get_atlas_rect(gamepad_frame, gamepad_cell_size)
+		else:
+			region_rect = get_atlas_rect(keyboard_frame, keyboard_cell_size)
 		return
 	ButtonHotkeyService.mode_changed.connect(_update_icon)
 	_update_icon()
@@ -45,9 +62,17 @@ func _ready() -> void:
 func _update_icon():
 	match ButtonHotkeyService.current_mode:
 		ButtonHotkeyService.MODE.KEYBOARD:
-			region_rect = get_atlas_rect(keyboard_frame, keyboard_cell_size)
+			if display_mode == DISPLAY_MODE.GAMEPAD:
+				hide()
+			else:
+				show()
+				region_rect = get_atlas_rect(keyboard_frame, keyboard_cell_size)
 		ButtonHotkeyService.MODE.GAMEPAD:
-			region_rect = get_atlas_rect(gamepad_frame, gamepad_cell_size)
+			if display_mode == DISPLAY_MODE.KEYBOARD:
+				hide()
+			else:
+				show()
+				region_rect = get_atlas_rect(gamepad_frame, gamepad_cell_size)
 
 func get_atlas_rect(atlas_frame:int, size:Vector2 = Vector2(1,1)):
 	var altasCellSize = texture.get_size() / atlas_params.atlas_size

--- a/scenes/ui/icons/hotkey.tscn
+++ b/scenes/ui/icons/hotkey.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3 uid="uid://dbuy7ss84alp"]
+
+[ext_resource type="Texture2D" uid="uid://bpunwi45xf0cx" path="res://assets/gui/icons/controls/tilemap_packed.png" id="1_ppxay"]
+[ext_resource type="Script" path="res://scenes/ui/icons/hotkey.gd" id="2_f0f61"]
+
+[node name="hotkey" type="Sprite2D"]
+texture = ExtResource("1_ppxay")
+region_enabled = true
+region_rect = Rect2(0, 0, 16, 16)
+script = ExtResource("2_f0f61")

--- a/scenes/ui/menu/controls/game.tscn
+++ b/scenes/ui/menu/controls/game.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://crv1ageml0d4g"]
+[gd_scene load_steps=4 format=3 uid="uid://crv1ageml0d4g"]
 
 [ext_resource type="FontFile" uid="uid://dkpcsi5rudp7j" path="res://assets/fonts/ttf/courier.ttf" id="1_ubwp4"]
 [ext_resource type="Texture2D" uid="uid://bpunwi45xf0cx" path="res://assets/gui/icons/controls/tilemap_packed.png" id="2"]
+[ext_resource type="Script" path="res://scenes/ui/icons/hotkey.gd" id="3_7y3i1"]
 
 [node name="game" type="Control"]
 layout_mode = 3
@@ -39,32 +40,27 @@ text = "TR_CAMERA"
 points = PackedVector2Array(0, 27, 360, 27)
 width = 1.0
 
-[node name="key" type="Sprite2D" parent="binds/camera"]
+[node name="hotkey" type="Sprite2D" parent="binds/camera"]
 position = Vector2(180, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
 centered = false
-hframes = 34
-vframes = 24
-frame = 253
+region_enabled = true
+region_rect = Rect2(144, 32, 16, 16)
+script = ExtResource("3_7y3i1")
+keyboard_frame = 77
+gamepad_frame = 253
 
-[node name="key2" type="Sprite2D" parent="binds/camera"]
+[node name="hotkey2" type="Sprite2D" parent="binds/camera"]
 position = Vector2(230, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
 centered = false
-hframes = 34
-vframes = 24
-frame = 321
-
-[node name="key3" type="Sprite2D" parent="binds/camera"]
-position = Vector2(280, -7)
-scale = Vector2(2, 2)
-texture = ExtResource("2")
-centered = false
-hframes = 34
-vframes = 24
-frame = 77
+region_enabled = true
+region_rect = Rect2(0, 0, 16, 16)
+script = ExtResource("3_7y3i1")
+gamepad_frame = 321
+display_mode = 2
 
 [node name="switch_cam" type="Label" parent="binds"]
 layout_mode = 0
@@ -79,16 +75,8 @@ text = "TR_CAM_SW"
 points = PackedVector2Array(0, 27, 360, 27)
 width = 1.0
 
-[node name="key" type="Sprite2D" parent="binds/switch_cam"]
-position = Vector2(180, -7)
-scale = Vector2(2, 2)
-texture = ExtResource("2")
-centered = false
-hframes = 34
-vframes = 24
-frame = 650
-
 [node name="key2" type="Sprite2D" parent="binds/switch_cam"]
+visible = false
 position = Vector2(230, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -107,6 +95,17 @@ hframes = 34
 vframes = 24
 frame = 77
 
+[node name="hotkey" type="Sprite2D" parent="binds/switch_cam"]
+position = Vector2(180, -7)
+scale = Vector2(2, 2)
+texture = ExtResource("2")
+centered = false
+region_enabled = true
+region_rect = Rect2(336, 48, 16, 16)
+script = ExtResource("3_7y3i1")
+keyboard_frame = 123
+gamepad_frame = 650
+
 [node name="zoom" type="Label" parent="binds"]
 layout_mode = 0
 offset_left = 20.0
@@ -121,6 +120,7 @@ points = PackedVector2Array(0, 27, 360, 27)
 width = 1.0
 
 [node name="key" type="Sprite2D" parent="binds/zoom"]
+visible = false
 position = Vector2(180, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -130,6 +130,7 @@ vframes = 24
 frame = 585
 
 [node name="key2" type="Sprite2D" parent="binds/zoom"]
+visible = false
 position = Vector2(230, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -139,6 +140,7 @@ vframes = 24
 frame = 586
 
 [node name="key3" type="Sprite2D" parent="binds/zoom"]
+visible = false
 position = Vector2(280, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -146,6 +148,28 @@ centered = false
 hframes = 34
 vframes = 24
 frame = 82
+
+[node name="hotkey" type="Sprite2D" parent="binds/zoom"]
+position = Vector2(180, -7)
+scale = Vector2(2, 2)
+texture = ExtResource("2")
+centered = false
+region_enabled = true
+region_rect = Rect2(224, 32, 16, 16)
+script = ExtResource("3_7y3i1")
+keyboard_frame = 82
+gamepad_frame = 585
+
+[node name="hotkey2" type="Sprite2D" parent="binds/zoom"]
+position = Vector2(230, -7)
+scale = Vector2(2, 2)
+texture = ExtResource("2")
+centered = false
+region_enabled = true
+region_rect = Rect2(0, 0, 16, 16)
+script = ExtResource("3_7y3i1")
+gamepad_frame = 586
+display_mode = 2
 
 [node name="select" type="Label" parent="binds"]
 layout_mode = 0
@@ -161,6 +185,7 @@ points = PackedVector2Array(0, 27, 360, 27)
 width = 1.0
 
 [node name="key" type="Sprite2D" parent="binds/select"]
+visible = false
 position = Vector2(180, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -170,6 +195,7 @@ vframes = 24
 frame = 47
 
 [node name="key2" type="Sprite2D" parent="binds/select"]
+visible = false
 position = Vector2(230, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -179,6 +205,7 @@ vframes = 24
 frame = 77
 
 [node name="key3" type="Sprite2D" parent="binds/select"]
+visible = false
 position = Vector2(280, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -188,6 +215,7 @@ vframes = 24
 frame = 235
 
 [node name="key4" type="Sprite2D" parent="binds/select"]
+visible = false
 position = Vector2(312, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -195,6 +223,29 @@ centered = false
 hframes = 34
 vframes = 24
 frame = 67
+
+[node name="hotkey" type="Sprite2D" parent="binds/select"]
+position = Vector2(180, -7)
+scale = Vector2(2, 2)
+texture = ExtResource("2")
+centered = false
+region_enabled = true
+region_rect = Rect2(144, 32, 16, 16)
+script = ExtResource("3_7y3i1")
+keyboard_frame = 77
+gamepad_frame = 47
+
+[node name="hotkey2" type="Sprite2D" parent="binds/select"]
+position = Vector2(230, -7)
+scale = Vector2(2, 2)
+texture = ExtResource("2")
+centered = false
+region_enabled = true
+region_rect = Rect2(496, 96, 48, 16)
+script = ExtResource("3_7y3i1")
+keyboard_frame = 235
+keyboard_cell_size = Vector2(3, 1)
+display_mode = 1
 
 [node name="back" type="Label" parent="binds"]
 layout_mode = 0
@@ -210,6 +261,7 @@ points = PackedVector2Array(0, 27, 360, 27)
 width = 1.0
 
 [node name="key" type="Sprite2D" parent="binds/back"]
+visible = false
 position = Vector2(180, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -219,6 +271,7 @@ vframes = 24
 frame = 48
 
 [node name="key2" type="Sprite2D" parent="binds/back"]
+visible = false
 position = Vector2(230, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -237,6 +290,17 @@ hframes = 34
 vframes = 24
 frame = 77
 
+[node name="hotkey" type="Sprite2D" parent="binds/back"]
+position = Vector2(180, -7)
+scale = Vector2(2, 2)
+texture = ExtResource("2")
+centered = false
+region_enabled = true
+region_rect = Rect2(160, 32, 16, 16)
+script = ExtResource("3_7y3i1")
+keyboard_frame = 78
+gamepad_frame = 48
+
 [node name="nav" type="Label" parent="binds"]
 layout_mode = 0
 offset_left = 20.0
@@ -251,6 +315,7 @@ points = PackedVector2Array(0, 27, 360, 27)
 width = 1.0
 
 [node name="key" type="Sprite2D" parent="binds/nav"]
+visible = false
 position = Vector2(130, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -260,6 +325,7 @@ vframes = 24
 frame = 253
 
 [node name="key2" type="Sprite2D" parent="binds/nav"]
+visible = false
 position = Vector2(180, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -269,6 +335,7 @@ vframes = 24
 frame = 68
 
 [node name="key3" type="Sprite2D" parent="binds/nav"]
+visible = false
 position = Vector2(230, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -278,6 +345,7 @@ vframes = 24
 frame = 166
 
 [node name="key4" type="Sprite2D" parent="binds/nav"]
+visible = false
 position = Vector2(265, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -287,6 +355,7 @@ vframes = 24
 frame = 167
 
 [node name="key5" type="Sprite2D" parent="binds/nav"]
+visible = false
 position = Vector2(300, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -296,6 +365,7 @@ vframes = 24
 frame = 168
 
 [node name="key6" type="Sprite2D" parent="binds/nav"]
+visible = false
 position = Vector2(335, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -303,6 +373,50 @@ centered = false
 hframes = 34
 vframes = 24
 frame = 169
+
+[node name="hotkey" type="Sprite2D" parent="binds/nav"]
+position = Vector2(130, -7)
+scale = Vector2(2, 2)
+texture = ExtResource("2")
+centered = false
+region_enabled = true
+region_rect = Rect2(480, 64, 16, 16)
+script = ExtResource("3_7y3i1")
+keyboard_frame = 166
+gamepad_frame = 68
+
+[node name="hotkey2" type="Sprite2D" parent="binds/nav"]
+position = Vector2(180, -7)
+scale = Vector2(2, 2)
+texture = ExtResource("2")
+centered = false
+region_enabled = true
+region_rect = Rect2(496, 64, 16, 16)
+script = ExtResource("3_7y3i1")
+keyboard_frame = 167
+gamepad_frame = 253
+
+[node name="hotkey3" type="Sprite2D" parent="binds/nav"]
+position = Vector2(230, -7)
+scale = Vector2(2, 2)
+texture = ExtResource("2")
+centered = false
+region_enabled = true
+region_rect = Rect2(512, 64, 16, 16)
+script = ExtResource("3_7y3i1")
+keyboard_frame = 168
+display_mode = 1
+
+[node name="hotkey4" type="Sprite2D" parent="binds/nav"]
+position = Vector2(280, -7)
+scale = Vector2(2, 2)
+texture = ExtResource("2")
+centered = false
+region_enabled = true
+region_rect = Rect2(528, 64, 16, 16)
+script = ExtResource("3_7y3i1")
+keyboard_frame = 169
+display_mode = 1
 
 [node name="menu" type="Label" parent="binds"]
 layout_mode = 0
@@ -318,6 +432,7 @@ points = PackedVector2Array(0, 27, 360, 27)
 width = 1.0
 
 [node name="key" type="Sprite2D" parent="binds/menu"]
+visible = false
 position = Vector2(180, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -327,6 +442,7 @@ vframes = 24
 frame = 651
 
 [node name="key2" type="Sprite2D" parent="binds/menu"]
+visible = false
 position = Vector2(230, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -336,6 +452,7 @@ vframes = 24
 frame = 155
 
 [node name="key3" type="Sprite2D" parent="binds/menu"]
+visible = false
 position = Vector2(280, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -343,6 +460,29 @@ centered = false
 hframes = 34
 vframes = 24
 frame = 17
+
+[node name="hotkey" type="Sprite2D" parent="binds/menu"]
+position = Vector2(180, -7)
+scale = Vector2(2, 2)
+texture = ExtResource("2")
+centered = false
+region_enabled = true
+region_rect = Rect2(304, 64, 16, 16)
+script = ExtResource("3_7y3i1")
+keyboard_frame = 155
+gamepad_frame = 651
+
+[node name="hotkey2" type="Sprite2D" parent="binds/menu"]
+position = Vector2(230, -7)
+scale = Vector2(2, 2)
+texture = ExtResource("2")
+centered = false
+region_enabled = true
+region_rect = Rect2(272, 0, 16, 16)
+script = ExtResource("3_7y3i1")
+keyboard_frame = 17
+gamepad_frame = 586
+display_mode = 1
 
 [node name="end_turn" type="Label" parent="binds"]
 layout_mode = 0
@@ -358,6 +498,7 @@ points = PackedVector2Array(0, 27, 360, 27)
 width = 1.0
 
 [node name="key" type="Sprite2D" parent="binds/end_turn"]
+visible = false
 position = Vector2(180, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -367,6 +508,7 @@ vframes = 24
 frame = 50
 
 [node name="key2" type="Sprite2D" parent="binds/end_turn"]
+visible = false
 position = Vector2(230, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -376,6 +518,7 @@ vframes = 24
 frame = 157
 
 [node name="key3" type="Sprite2D" parent="binds/end_turn"]
+visible = false
 position = Vector2(280, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -383,6 +526,29 @@ centered = false
 hframes = 34
 vframes = 24
 frame = 79
+
+[node name="hotkey" type="Sprite2D" parent="binds/end_turn"]
+position = Vector2(180, -7)
+scale = Vector2(2, 2)
+texture = ExtResource("2")
+centered = false
+region_enabled = true
+region_rect = Rect2(336, 64, 16, 16)
+script = ExtResource("3_7y3i1")
+keyboard_frame = 157
+gamepad_frame = 50
+
+[node name="hotkey2" type="Sprite2D" parent="binds/end_turn"]
+position = Vector2(230, -7)
+scale = Vector2(2, 2)
+texture = ExtResource("2")
+centered = false
+region_enabled = true
+region_rect = Rect2(176, 32, 16, 16)
+script = ExtResource("3_7y3i1")
+keyboard_frame = 79
+gamepad_frame = 586
+display_mode = 1
 
 [node name="unit_stats" type="Label" parent="binds"]
 layout_mode = 0
@@ -398,6 +564,7 @@ points = PackedVector2Array(0, 27, 360, 27)
 width = 1.0
 
 [node name="key" type="Sprite2D" parent="binds/unit_stats"]
+visible = false
 position = Vector2(180, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -407,6 +574,7 @@ vframes = 24
 frame = 49
 
 [node name="key2" type="Sprite2D" parent="binds/unit_stats"]
+visible = false
 position = Vector2(230, -7)
 scale = Vector2(2, 2)
 texture = ExtResource("2")
@@ -424,3 +592,14 @@ centered = false
 hframes = 34
 vframes = 24
 frame = 79
+
+[node name="hotkey" type="Sprite2D" parent="binds/unit_stats"]
+position = Vector2(180, -7)
+scale = Vector2(2, 2)
+texture = ExtResource("2")
+centered = false
+region_enabled = true
+region_rect = Rect2(320, 64, 16, 16)
+script = ExtResource("3_7y3i1")
+keyboard_frame = 156
+gamepad_frame = 49

--- a/scripts/services/button_hotkey_service.gd
+++ b/scripts/services/button_hotkey_service.gd
@@ -1,0 +1,17 @@
+extends Node
+
+enum MODE {KEYBOARD, GAMEPAD}
+
+var current_mode :MODE = MODE.KEYBOARD
+
+var atlas := load("res://assets/gui/icons/controls/tilemap_packed.png") as Texture2D
+
+signal mode_changed()
+
+func _input(event: InputEvent) -> void:
+	if event is InputEventJoypadButton and current_mode != MODE.GAMEPAD:
+		current_mode = MODE.GAMEPAD
+		mode_changed.emit()
+	elif event is InputEventKey and current_mode != MODE.KEYBOARD:
+		current_mode = MODE.KEYBOARD
+		mode_changed.emit()


### PR DESCRIPTION
These can be easily added to other places.
They support gamepad and keyboard icons at the same time, and the size is customizable (for spacebar icon for example).
It should detect gamepad keypresses automatically and update all icons. I can't test that, but it seems pretty trivial.

I think such contextual tips are much better than that panel on the side.

I would suggest binding these hotkey nodes directly to input action names, so the icons just read the bound hotkeys of the action and select an icon accordingly. That would enable user to remap hotkeys and see them change in game.
But that requires mapping all icons from icon atlas to their actual key names, which is probably quite a bit of work.
An easier alternative would be to just use text with a generic background icon (with some exceptions maybe).